### PR TITLE
Add TTD and Bellatrix epoch to consensus config

### DIFF
--- a/prater/config.yaml
+++ b/prater/config.yaml
@@ -3,6 +3,14 @@
 # Extends the mainnet preset
 PRESET_BASE: 'mainnet'
 
+# Transition
+# ---------------------------------------------------------------
+TERMINAL_TOTAL_DIFFICULTY: 10790000
+# By default, don't use these params
+TERMINAL_BLOCK_HASH: 0x0000000000000000000000000000000000000000000000000000000000000000
+TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH: 18446744073709551615
+
+
 # Genesis
 # ---------------------------------------------------------------
 # `2**14` (= 16,384)
@@ -26,7 +34,7 @@ ALTAIR_FORK_VERSION: 0x01001020
 ALTAIR_FORK_EPOCH: 36660
 # Bellatrix
 BELLATRIX_FORK_VERSION: 0x02001020
-BELLATRIX_FORK_EPOCH: 18446744073709551615
+BELLATRIX_FORK_EPOCH: 112260
 # Capella
 CAPELLA_FORK_VERSION: 0x03001020
 CAPELLA_FORK_EPOCH: 18446744073709551615
@@ -60,6 +68,12 @@ EJECTION_BALANCE: 16000000000
 MIN_PER_EPOCH_CHURN_LIMIT: 4
 # 2**16 (= 65,536)
 CHURN_LIMIT_QUOTIENT: 65536
+
+
+# Fork choice
+# ---------------------------------------------------------------
+# 40%
+PROPOSER_SCORE_BOOST: 40
 
 
 # Deposit contract


### PR DESCRIPTION
Update the Prater/Goerli config with the Bellatrix fork epoch and the TTD.

I also added the proposer score boost @ 40% which is now part of all network configs.