### PR TITLE
Remove faucet that is selling goerli funds

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ The Goerli testnet was merged with the Prater proof-of-stake beacon chain. This 
   - https://faucet.goerli.mudit.blog/
   - https://faucets.chain.link/goerli (No social media account required)
   - https://goerli-faucet.pk910.de/ (PoW powered, No social media account required)
-  - https://goerli-faucet.com/ ([Open Source](https://github.com/ayanamitech/ethereum-faucet), Telegram Bot authenticated, No social media account required)
 - Open RPC Endpoints:
   - https://goerli.prylabs.net
   - https://rpc.goerli.mudit.blog


### PR DESCRIPTION
Heya,

I'd like to propose removing the goerli-faucet.com faucet from the list of goerli faucets.

It has been a proper faucet earlier, but they've recently decided to add paid options to sell their goerli funds for own profit...
Besides of that, they've also started to steal goerli funds from other faucets (bots) & roninkaizen (abusive mass requests) to fund their faucet...
Both points are really not what the network needs, and the site should be removed from all official overviews.

Site has been removed from faucetlink, too.
I'd link the original github handle (@ayanamitech) to give that guy a chance to explain, 
but unfortunately he has deleted his github handle and doesn't respont on other threads, too.
