### PR TITLE
Rename Holli to Holešky

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><a href="https://github.com/ethereum/ropsten">Ropsten (2016)</a> | Rinkeby (2017) | <strong>Goerli (2019)</strong> | <a href="https://github.com/eth-clients/sepolia">Sepolia (2021)</a> | <a href="https://github.com/eth-clients/holesovice">Holli (2023)</a></p>
+<p align="center"><a href="https://github.com/ethereum/ropsten">Ropsten (2016)</a> | Rinkeby (2017) | <strong>Goerli (2019)</strong> | <a href="https://github.com/eth-clients/sepolia">Sepolia (2021)</a> | <a href="https://github.com/eth-clients/holesky">Holešky (2023)</a></p>
 <p align="center"><img src="./assets/goerli.png" /></p>
 
 # Goerli (Goerlitzer Testnet)


### PR DESCRIPTION
This PR updates the link so it is in line with how the repo calls itself now. See https://github.com/eth-clients/holesky/issues/4 for context.